### PR TITLE
Raise the event for every entity in a position.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -80,10 +80,6 @@ script.on_event(defines.events.on_built_entity, function(event)
     player.cursor_stack.set_stack({name = "wrench", count = 1})
     created_entity.destroy()
     entities = surface.find_entities{{ pos.x, pos.y }, { pos.x, pos.y }}
-    if #entities > 1 then
-      print('Error: more than one entity found here...')
-      return
-    end
 
     if player.gui.center.wrench then
       player.gui.center.wrench.destroy()
@@ -91,14 +87,15 @@ script.on_event(defines.events.on_built_entity, function(event)
 
     local entity
     if #entities == 1 then
-      entity = entities[1]
+       Entities.set_current(entities[1])
     else
-      entity = nil
+       Entities.set_current(nil)
     end
-
-    Entities.set_current(entity)
-    if (entity) then
-      game.raise_event(EntityClickEvent, { entity = entity, player = player })
+    
+    for _, entity in pairs(entities) do 
+       if (entity) then
+	  game.raise_event(EntityClickEvent, { entity = entity, player = player })
+       end
     end
   end
 end)


### PR DESCRIPTION
Instead of throwing an error when more than one entity is in a position,
raise the event for every entity at that position.
